### PR TITLE
KeyError during node2vec

### DIFF
--- a/ge/walker.py
+++ b/ge/walker.py
@@ -191,6 +191,8 @@ class RandomWalker:
 
             for edge in G.edges():
                 alias_edges[edge] = self.get_alias_edge(edge[0], edge[1])
+                if not G.is_directed():
+                    alias_edges[(edge[1], edge[0])] = self.get_alias_edge(edge[1], edge[0])
                 self.alias_edges = alias_edges
 
         self.alias_nodes = alias_nodes


### PR DESCRIPTION
This fixes a KeyError seen during node2vec when using non-directed graphs (example [here](https://github.com/shenweichen/GraphEmbedding/issues/5)) by allowing the walker to initialize both directions of graph edges.