### PR TITLE
[codex] Fix LINE edge sampling probabilities

### DIFF
--- a/ge/models/line.py
+++ b/ge/models/line.py
@@ -131,11 +131,10 @@ class LINE:
         self.node_accept, self.node_alias = create_alias_table(norm_prob)
 
         # create sampling table for edge
-        numEdges = self.graph.number_of_edges()
         total_sum = sum([self.graph[edge[0]][edge[1]].get('weight', 1.0)
                          for edge in self.graph.edges()])
-        norm_prob = [self.graph[edge[0]][edge[1]].get('weight', 1.0) *
-                     numEdges / total_sum for edge in self.graph.edges()]
+        norm_prob = [self.graph[edge[0]][edge[1]].get('weight', 1.0) /
+                     total_sum for edge in self.graph.edges()]
 
         self.edge_accept, self.edge_alias = create_alias_table(norm_prob)
 

--- a/tests/line_test.py
+++ b/tests/line_test.py
@@ -5,8 +5,40 @@ import pytest
 
 pytest.importorskip("tensorflow")
 from ge import LINE
+from ge.models import line as line_module
+from ge.utils import preprocess_nxgraph
 
 TEST_GRAPH_PATH = Path(__file__).resolve().parent / "Wiki_edgelist.txt"
+
+
+def test_LINE_sampling_tables_use_normalized_probabilities(monkeypatch):
+    graph = nx.DiGraph()
+    graph.add_edge("a", "b", weight=2)
+    graph.add_edge("a", "c", weight=6)
+
+    model = LINE.__new__(LINE)
+    model.graph = graph
+    model.idx2node, model.node2idx = preprocess_nxgraph(graph)
+    model.node_size = graph.number_of_nodes()
+
+    sampling_tables = []
+
+    def record_sampling_table(area_ratio):
+        sampling_tables.append(list(area_ratio))
+        return [1] * len(area_ratio), [0] * len(area_ratio)
+
+    monkeypatch.setattr(line_module, "create_alias_table", record_sampling_table)
+
+    LINE._gen_sampling_table(model)
+
+    node_probs, edge_probs = sampling_tables
+    expected_edge_probs = [
+        graph[edge[0]][edge[1]]["weight"] / 8 for edge in graph.edges()
+    ]
+
+    assert sum(node_probs) == pytest.approx(1)
+    assert sum(edge_probs) == pytest.approx(1)
+    assert edge_probs == pytest.approx(expected_edge_probs)
 
 
 def test_LINE():


### PR DESCRIPTION
## Summary

- Normalize LINE edge sampling probabilities before passing them to the alias table.
- Add a regression test that verifies both node and edge sampling tables receive probability distributions summing to 1.

## Root cause

`create_alias_table` expects normalized probabilities and scales them internally by table length. LINE edge sampling already multiplied each edge weight by `numEdges`, so the alias input summed to the number of edges instead of 1.

Addresses #31 and #51. This may also help investigate the LINE NaN reports in #33 and #73.

## Checks

- `git diff --check`
- `python -m pytest tests/line_test.py`
- `python -m pytest tests/examples_test.py -k line`
